### PR TITLE
[Footer] Clase fixed-bottom eliminada de update Error responsivo.

### DIFF
--- a/addEmploye.html
+++ b/addEmploye.html
@@ -112,7 +112,7 @@
   </div>
 
 
-  <div class="container navbar-fixed-bottom fixed-bottom">
+  <div class="container navbar-fixed-bottom">
     <footer class="py-5">
       <div class="d-flex flex-column flex-sm-row justify-content-between py-4 my-4 border-top">
         <p>&copy; 2022/2023 DuckLabs, Inc. Todos los derechos reservados.</p>


### PR DESCRIPTION
Ok, existía un error con el footer en el navegador móvil. Solucionado quitando la clase fixed-bottom.